### PR TITLE
More reactive

### DIFF
--- a/tests/__snapshots__/Formidable_Test.bs.js.snap
+++ b/tests/__snapshots__/Formidable_Test.bs.js.snap
@@ -13,6 +13,11 @@ exports[`Formidable Component renders 1`] = `
     <div>
       <div>
         Email
+        <span
+          style="color: red;"
+        >
+          *
+        </span>
       </div>
       <input
         data-testid="email"


### PR DESCRIPTION
This pr makes the form a bit more reactive:
- `submit` now returns a promise which can help solving the stale closure issue
- `onSubmit` is not required, you can now use the Promise in order to handle success/errors in a useEffect hook

This pr comes with 2 changes in the API:
- Non breaking: `onSubmit` is optional. Since it user to be required until now, it shouldn't break any source code.
- _Breaking_: `submit` returns a Promise instead of unit, which means you will have to handle, or `ignore` the returned value.