### PR TITLE
Simplify the API and encourage the Functor or runtime ways

### DIFF
--- a/example/Components.res
+++ b/example/Components.res
@@ -65,7 +65,7 @@ module TextInput = {
           disabled=isDisabled
           name
           onBlur
-          onChange={Formidable.Events.handle(onChange)}
+          onChange={Formidable.Events.handleWithValue(onChange)}
           onFocus
           value
         />

--- a/src/FormidableEvents.res
+++ b/src/FormidableEvents.res
@@ -17,12 +17,12 @@ let eventTargetValue = event =>
   ->Js.Nullable.toOption
   ->Option.getWithDefault("")
 
-let handle = (~preventDefault=false, ~stopPropagation=false, f, event) => {
+let handleWithValue = (~preventDefault=false, ~stopPropagation=false, f, event) => {
   event->handle_(~preventDefault, ~stopPropagation)
   event->eventTargetValue->f
 }
 
-let handle' = (~preventDefault=false, ~stopPropagation=false, f, event) => {
+let handle = (~preventDefault=false, ~stopPropagation=false, f, event) => {
   handle_(~preventDefault, ~stopPropagation, event)
   f()
 }


### PR DESCRIPTION
And rationalize the 3 ways to define a form ^^

This pr is breaking in several ways:
- onSubmit/onSubmitError handlers have been renamed to onSuccess/OnError that are shorter (and more explicit for the former), it's debatable and we can find proper names we all like 👍 
- The handlers are not defined in the functor, but in the hook which come with some benefits like the flexibility, but also some drawbacks (see below). The code change is as follow:
```
let makeForm = Formidable.make(~values=module(Values), ~error=module(I18n.Error))

module Form = unpack(makeForm(~onSubmit=_values => (), ~onSubmitError=(_values, _errors) => (), ()))

// In the hook
let {Formidable.Hook.values} = Form.use()

// Is now

module Form = Formidable.Make(Values, I18n.Error)

let {Formidable.Hook.values} = Form.use(
  ~onSuccess=values => Js.log2("Success: ", values),
  ~onError=(values, errors) => Js.log3("Error: ", errors, values),
  (),
)

// Obviously you can skip the handlers
let {Formidable.Hook.values} = Form.use()
```
- Consumer API is lighter, and contains only the state with the fields and the states, so no ways to _change_ the state anymore, but it might come back after we address #26
- `onSubmit` must be passed down to the `Form`. It used to be implicit but it can't be anymore

The code should be also faster as we don't subscribe several times to the same hook anymore and encourage the end use to subscribe once and pass the values down the components. Also, regarding the onError/onSuccess handlers system it might get dropped at one point, so we probably don't need to overthink it now https://github.com/scoville/re-formidable/issues/26