### PR TITLE
Improve validation description safety

### DIFF
--- a/example/App.res
+++ b/example/App.res
@@ -23,7 +23,7 @@ module Values = {
 // but in some cases you can simply use the hook provided by Formidable
 // or define your form at runtime using the make function
 // All the above solutions come with pros and cons
-module Form = Formidable.Make(Values, I18n.Error)
+module Form = Formidable.Make(Values, I18n.Error, Validations.Label)
 
 open Validations
 

--- a/example/Components.res
+++ b/example/Components.res
@@ -46,7 +46,7 @@ module TextInput = {
   @react.component
   let make = React.memo((
     ~field as {
-      Formidable.Props.Field.isDisabled: isDisabled,
+      isDisabled,
       isFocused,
       label,
       name,
@@ -56,10 +56,10 @@ module TextInput = {
       status,
       hasValidation,
       value,
-    },
+    }: Formidable.Props.Field.t<_, _, Validations.Label.t>,
   ) =>
     <div>
-      <Label required={hasValidation("required")} value=label />
+      <Label required={hasValidation(#required)} value=label />
       <Test id=name>
         <input
           disabled=isDisabled

--- a/example/Validations.res
+++ b/example/Validations.res
@@ -1,7 +1,11 @@
 include Formidable.Validations
 
+module Label = {
+  type t = [#required | #email | #equals]
+}
+
 let required = {
-  Description.names: list{"required"},
+  Description.names: list{#required},
   validator: ({label, value}) =>
     switch value {
     | "" => #error(#error(("required", label)))
@@ -12,7 +16,7 @@ let required = {
 let emailRegEx = %re("/.+@.+/")
 
 let email = {
-  Description.names: list{"email"},
+  Description.names: list{#email},
   validator: ({label, value}) =>
     if emailRegEx->Js.Re.test_(value) {
       #ok(value)
@@ -22,7 +26,7 @@ let email = {
 }
 
 let equals = lens => {
-  Description.names: list{"equals"},
+  Description.names: list{#equals},
   validator: ({label, value, values}) =>
     if lens.Optic.Lens.get(values) == value {
       #ok(value)

--- a/src/FormidableValidations.res
+++ b/src/FormidableValidations.res
@@ -27,13 +27,16 @@ module Validator = {
 }
 
 module Description = {
-  type t<'values, 'value, 'error> = {
-    names: list<string>,
+  type t<'values, 'value, 'error, 'label> = {
+    names: list<'label>,
     validator: Validator.t<'values, 'value, 'error>,
   }
 }
 
-type t<'values, 'value, 'error> = (Strategy.t, Description.t<'values, 'value, 'error>)
+type t<'values, 'value, 'error, 'label> = (
+  Strategy.t,
+  Description.t<'values, 'value, 'error, 'label>,
+)
 
 let compose = (
   {Description.names: names, validator},


### PR DESCRIPTION
Closes https://github.com/scoville/re-formidable/issues/23

When definining a Form you need to add the ValidationLabel module first:

```rescript
module Form = Formidable.Make(Values, I18n.Error)
// Is now
module Form = Formidable.Make(Values, I18n.Error, Validations.Label)
```

Where the Label module looks something like that:

```rescript
module Label = {
  type t = [#required | #email]
}
```

## Why?

In general to keep in sync validations and ui we use the `hasValidation` help injected in inputs:

```rescript
@react.component
let make = (~field as {hasValidation}) =>
  <div> {(hasValidation("required") ? "Field is required" : Field is optional")->React.string}</div>
```

It's rather nice to keep things tighly related to each other but using strings will not catch some typos that won't be noticed until we reach the runtime 😕 

From now on you can type `hasValidation(#required)`, and typing `hasValidation(#reqiured)` would just not compile 😄 

If you're concerned about the verbosity of the form declaration, let's keep in mind 2 things:
- Form are rarely declared
- There is a way to partially apply a functor that "hides" that boilerplate logic (more of this in the next PR)