### PR TITLE
Revert functor arguments order

### DIFF
--- a/example/App.res
+++ b/example/App.res
@@ -23,7 +23,14 @@ module Values = {
 // but in some cases you can simply use the hook provided by Formidable
 // or define your form at runtime using the make function
 // All the above solutions come with pros and cons
-module Form = Formidable.Make(Values, I18n.Error, Validations.Label)
+
+// Since we know our whole application will rely on the same validation labels and errors
+// we can define a form maker functor very easily as follow:
+module MakeForm = Formidable.Make(Validations.Label, I18n.Error)
+
+// We can now use the MakeForm functor from above to build any form using any kind of values
+// all the validations and input components will just work, and the creation of a new form is trivial
+module Form = MakeForm(Values)
 
 open Validations
 

--- a/src/Formidable.res
+++ b/src/Formidable.res
@@ -191,7 +191,7 @@ module type Form = {
   ) => React.element
 }
 
-module Make = (Values: Values, Error: Type, ValidationLabel: Type): (
+module Make = (ValidationLabel: Type, Error: Type, Values: Values): (
   Form
     with type values = Values.t
     and type error = Error.t
@@ -442,31 +442,31 @@ module Make = (Values: Values, Error: Type, ValidationLabel: Type): (
   }
 }
 
-type t<'values, 'error, 'validationLabel> = module(Form with
-  type error = 'error
+type t<'validationLabel, 'error, 'values> = module(Form with
+  type validationLabel = 'validationLabel
+  and type error = 'error
   and type values = 'values
-  and type validationLabel = 'validationLabel
 )
 
 let make = (
-  type values error validationLabel,
-  ~values as module(Values: Values with type t = values),
-  ~error as module(Error: Type with type t = error),
+  type validationLabel error values,
   ~validationLabel as module(ValidationLabel: Type with type t = validationLabel),
-): t<values, error, validationLabel> => {
-  module(Make(Values, Error, ValidationLabel))
+  ~error as module(Error: Type with type t = error),
+  ~values as module(Values: Values with type t = values),
+): t<validationLabel, error, values> => {
+  module(Make(ValidationLabel, Error, Values))
 }
 
 let use = (
-  type values error validationLabel,
-  ~values: module(Values with type t = values),
-  ~error: module(Type with type t = error),
+  type validationLabel error values,
   ~validationLabel: module(Type with type t = validationLabel),
+  ~error: module(Type with type t = error),
+  ~values: module(Values with type t = values),
   ~onSuccess=?,
   ~onError=?,
   (),
 ) => {
-  let module(Form) = make(~values, ~error, ~validationLabel)
+  let module(Form) = make(~validationLabel, ~error, ~values)
 
   React.useMemo0(() => {
     Form.use(~onSuccess?, ~onError?, ())
@@ -474,14 +474,14 @@ let use = (
 }
 
 let use1 = (
-  type values error validationLabel,
-  ~values: module(Values with type t = values),
-  ~error: module(Type with type t = error),
+  type validationLabel error values,
   ~validationLabel: module(Type with type t = validationLabel),
+  ~error: module(Type with type t = error),
+  ~values: module(Values with type t = values),
   ~onSuccess=?,
   ~onError=?,
 ) => {
-  let module(Form) = make(~values, ~error, ~validationLabel)
+  let module(Form) = make(~validationLabel, ~error, ~values)
 
   React.useMemo1(() => {
     Form.use(~onSuccess?, ~onError?, ())


### PR DESCRIPTION
While it may seem a bit confusing to revert the arguments order of the make functor (and of the make functions), it's mostly as it eases form definition.

We can now simply define a global FormMaker that we'll use throughout the whole app, and use it to spawn functors here and there:

```rescript
module MakeForm = Formidable.Make(Validations.Label, I18n.Error)

module Form = MakeForm(Values)
```

Solved the concerns raised by #28 
