### PR TITLE
Use a slightly more explicit api surface to define validations without the need for explicit lists

### DIFF
--- a/example/Validations.res
+++ b/example/Validations.res
@@ -4,33 +4,33 @@ module Label = {
   type t = [#required | #email | #equals]
 }
 
-let required = {
-  Description.names: list{#required},
-  validator: ({label, value}) =>
+let required = (
+  #name(#required),
+  ({Validator.Args.label: label, value}) =>
     switch value {
     | "" => #error(#error(("required", label)))
     | _ => #ok(value)
     },
-}
+)
 
 let emailRegEx = %re("/.+@.+/")
 
-let email = {
-  Description.names: list{#email},
-  validator: ({label, value}) =>
+let email = (
+  #name(#email),
+  ({Validator.Args.label: label, value}) =>
     if emailRegEx->Js.Re.test_(value) {
       #ok(value)
     } else {
       #error(#error(("email", label)))
     },
-}
+)
 
-let equals = lens => {
-  Description.names: list{#equals},
-  validator: ({label, value, values}) =>
+let equals = lens => (
+  #name(#equals),
+  ({Validator.Args.label: label, value, values}) =>
     if lens.Optic.Lens.get(values) == value {
       #ok(value)
     } else {
       #error(#error(("equals", label)))
     },
-}
+)

--- a/src/Formidable.res
+++ b/src/Formidable.res
@@ -316,16 +316,14 @@ module Make = (ValidationLabel: Type, Error: Type, Values: Values): (
 
       let validationNames =
         validations->Option.mapWithDefault([], validations =>
-          validations->ArrayExtra.flatMap(validation =>
-            validation->Validations.getNames->List.toArray
-          )
+          validations->ArrayExtra.flatMap(Validations.getNames)
         )
 
       let hasValidation = name => validationNames->Js.Array2.includes(name)
 
       let validate = React.useCallback1((validationContext, values) =>
         validations->Option.mapWithDefault(#valid, validations =>
-          switch validations->Array.keepMap(((strategy, {validator})) =>
+          switch validations->Array.keepMap(((strategy, (_, validator))) =>
             if Validations.shouldValidate(~context=validationContext, ~strategy) {
               switch validator({
                 Validations.Validator.Args.label: errorLabel->OptionExtra.or(label),


### PR DESCRIPTION
From now on we can define a validation this way:

```rescript
let required = (
  #name(#required),
  ({Validator.Args.label: label, value}) =>
    switch value {
    | "" => #error(#error(("required", label)))
    | _ => #ok(value)
    },
)
```

Some changes:
- Under the hood, no more Lists, at all
- No more a record, since we have `#name` it's probably explicit enough, and it prevents this: `names: #name(#required)` which is a bit weird
- Might have type issues if you use `#names([...])` in the code, but it's clearly not a use case


It's a simple alternative to https://github.com/scoville/re-formidable/pull/22 that should be more lightweight and not as breaking 👍 

Closes https://github.com/scoville/re-formidable/pull/22
Closes https://github.com/scoville/re-formidable/issues/6