### PR TITLE
Add a setFieldState function to the hook and an example of Async validation

### DIFF
--- a/example/App.res
+++ b/example/App.res
@@ -41,15 +41,13 @@ let emailValidations = [(#onChange, required->compose(email))]
 
 let passwordConfirmValidations = [(#onChange, equals(Values.password))]
 
+// The error appended to the email when it already exists
+let emailAlreadyExistsError: I18n.Error.t = #error("email", Some("already exists"))
+
 module Child = {
   @react.component
   let make = (~onInputBlur=?, ~onInputChange=?, ~onInputFocus=?) => {
-    let {
-      Formidable.Hook.reset: reset,
-      state: {values: {Values.email: email}},
-      setFieldStatus,
-      submit,
-    } = Form.use(
+    let {addError, removeError, reset, state: {values: {email}}, submit} = Form.use(
       ~onSuccess=values => Js.log2("Success: ", values),
       ~onError=(values, errors) => Js.log3("Error: ", errors, values),
       (),
@@ -60,8 +58,8 @@ module Child = {
     React.useEffect1(() => {
       switch emailValidationResponse {
       | Init | Loading => ignore()
-      | Data(_) => setFieldStatus("email", #valid)
-      | Error(_) => setFieldStatus("email", #errors([#error("email", Some("already exists"))]))
+      | Data(_) => removeError("email", emailAlreadyExistsError)
+      | Error(_) => addError("email", emailAlreadyExistsError)
       }
 
       None

--- a/example/App.res
+++ b/example/App.res
@@ -8,6 +8,7 @@ module Values = {
     password: string,
     passwordConfirm: string,
     email: string,
+    hobbies: array<string>,
   }
 
   let init = {
@@ -16,6 +17,7 @@ module Values = {
     password: "",
     passwordConfirm: "",
     email: "",
+    hobbies: [""],
   }
 }
 
@@ -47,7 +49,14 @@ let emailAlreadyExistsError: I18n.Error.t = #error("email", Some("already exists
 module Child = {
   @react.component
   let make = (~onInputBlur=?, ~onInputChange=?, ~onInputFocus=?) => {
-    let {addError, removeError, reset, state: {values: {email}}, submit} = Form.use(
+    let {
+      addError,
+      removeError,
+      reset,
+      state: {values: {email, hobbies}},
+      setValues,
+      submit,
+    } = Form.use(
       ~onSuccess=values => Js.log2("Success: ", values),
       ~onError=(values, errors) => Js.log3("Error: ", errors, values),
       (),
@@ -122,12 +131,31 @@ module Child = {
         lens=Values.age>
         {field => <TextInput field />}
       </Form.Field>
-      <Test id="submit"> <button type_="submit"> {"Submit"->React.string} </button> </Test>
+      {hobbies
+      ->Array.mapWithIndex((index, _hobby) =>
+        <Form.Field
+          name={`hobby-${index->Int.toString}`}
+          onBlur=?onInputBlur
+          onChange=?onInputChange
+          onFocus=?onInputFocus
+          label={`Hobby - ${(index + 1)->Int.toString}`}
+          lens={Values.hobbies->Optic.Lens.compose(Optic.Common.Array.indexExn(index))}>
+          {field => <TextInput field />}
+        </Form.Field>
+      )
+      ->React.array}
+      <button
+        type_="button"
+        onClick={_ =>
+          setValues(values => {...values, hobbies: values.hobbies->Js.Array2.concat([""])})}>
+        {"Add Hobby"->React.string}
+      </button>
       <Test id="reset">
         <button type_="button" onClick={Formidable.Events.handle(reset)}>
           {"Reset"->React.string}
         </button>
       </Test>
+      <Test id="submit"> <button type_="submit"> {"Submit"->React.string} </button> </Test>
     </Form>
   }
 }

--- a/example/Components.res
+++ b/example/Components.res
@@ -9,7 +9,7 @@ module Errors = {
     <div style={ReactDOMStyle.make(~color="red", ())}>
       {value
       ->Array.map((#error(name, _) as error) =>
-        <div key=name> {("Field has errors: " ++ I18n.translate(error))->React.string} </div>
+        <div key=name> {`Field has errors: ${I18n.translate(error)}`->React.string} </div>
       )
       ->React.array}
     </div>
@@ -18,15 +18,19 @@ module Errors = {
 
 module Status = {
   @react.component
-  let make = (~value) =>
-    <div>
-      {switch value {
-      | #pristine => "Field is pristine"->React.string
-      | #touched => "Field is touched"->React.string
-      | #valid => "Field is valid"->React.string
-      | #errors(errors) => <Errors value=errors />
-      }}
-    </div>
+  let make = (~validating, ~value) =>
+    if validating {
+      <div> {"Validating..."->React.string} </div>
+    } else {
+      <div>
+        {switch value {
+        | #pristine => "Field is pristine"->React.string
+        | #touched => "Field is touched"->React.string
+        | #valid => "Field is valid"->React.string
+        | #errors(errors) => <Errors value=errors />
+        }}
+      </div>
+    }
 }
 
 module Label = {
@@ -57,12 +61,13 @@ module TextInput = {
       hasValidation,
       value,
     }: Formidable.Props.Field.t<_, _, Validations.Label.t>,
+    ~validating=false,
   ) =>
     <div>
       <Label required={hasValidation(#required)} value=label />
       <Test id=name>
         <input
-          disabled=isDisabled
+          disabled={isDisabled || validating}
           name
           onBlur
           onChange={Formidable.Events.handleWithValue(onChange)}
@@ -71,7 +76,7 @@ module TextInput = {
         />
       </Test>
       <div> {(isFocused ? "Focus" : "Blur")->React.string} </div>
-      <Status value=status />
+      <Status validating value=status />
     </div>
   )
 }

--- a/example/FakeFetch.res
+++ b/example/FakeFetch.res
@@ -1,0 +1,23 @@
+// Simulates a fetch hook
+
+type t<'data, 'error> = Init | Loading | Data('data) | Error('error)
+
+let useFetch = (~path) => {
+  let (response, setResponse) = React.useState(() => Init)
+
+  (
+    response,
+    (~body) => {
+      setResponse(_ => Loading)
+
+      let data = switch path->Js.String2.split("/")->Js.Array2.filter(pathPart => pathPart != "") {
+      | ["email", "exists"] when body->Js.Dict.get("email") == Some("already@exists.com") =>
+        Error(#alreadyExists)
+      | ["email", "exists"] => Data("Ok")
+      | _ => Error(#notFound)
+      }
+
+      Js.Global.setTimeout(() => setResponse(_ => data), 1000)->ignore
+    },
+  )
+}

--- a/example/FakeFetch.res
+++ b/example/FakeFetch.res
@@ -5,6 +5,16 @@ type t<'data, 'error> = Init | Loading | Data('data) | Error('error)
 let useFetch = (~path) => {
   let (response, setResponse) = React.useState(() => Init)
 
+  // Prevents memory leaks
+  let (timeoutId, setTimeoutId) = React.useState(() => None)
+
+  React.useEffect1(() =>
+    switch timeoutId {
+    | None => None
+    | Some(timeoutId) => Some(() => Js.Global.clearTimeout(timeoutId))
+    }
+  , [timeoutId])
+
   (
     response,
     (~body) => {
@@ -17,7 +27,7 @@ let useFetch = (~path) => {
       | _ => Error(#notFound)
       }
 
-      Js.Global.setTimeout(() => setResponse(_ => data), 1000)->ignore
+      setTimeoutId(_ => Some(Js.Global.setTimeout(() => setResponse(_ => data), 200)))
     },
   )
 }

--- a/example/I18n.res
+++ b/example/I18n.res
@@ -2,4 +2,4 @@ module Error = {
   type t = [#error(string, option<string>)]
 }
 
-let translate = (#error(name, label)) => label->Option.getWithDefault("") ++ "/" ++ name
+let translate = (#error(name, label)) => `${label->Option.getWithDefault("")}/${name}`

--- a/src/Formidable.res
+++ b/src/Formidable.res
@@ -414,6 +414,7 @@ module Make = (ValidationLabel: Type, Error: Type, Values: Values): (
         onChange'->Option.forEach(onChange' => onChange'(Optic.Lens.get(lens, values)))
 
         modifiers.setValues(values)
+
         validateAndUpdate(Some(#onChange), values)
       }
 

--- a/tests/Formidable_Test.res
+++ b/tests/Formidable_Test.res
@@ -188,7 +188,7 @@ describe("Formidable", () => {
     })
 
     test("On change listener", () => {
-      let (spy, onChange) = Handler.make(value => "changed: " ++ value)
+      let (spy, onChange) = Handler.make(value => `changed: ${value}`)
 
       let app = renderApp(~onChange, ())
 

--- a/tests/Formidable_Test.res
+++ b/tests/Formidable_Test.res
@@ -10,6 +10,8 @@ describe("Formidable", () => {
   })
 
   describe("Field (example: email)", () => {
+    let existingEmail = "already@exists.com"
+
     let wrongEmail = "foobar.com"
 
     let validEmail = "foo@bar.com"
@@ -25,19 +27,49 @@ describe("Formidable", () => {
     test("Change focus status - focus", () => {
       let app = renderApp()
 
-      app->email.input->FireEvent.focus
+      act(() => app->email.input->FireEvent.focus)
 
       email.expectToMatchSnapshot(app)
     })
 
-    test("Change focus status and trigger required error - focus then blur", () => {
+    test(
+      "Change focus status and trigger only displays loading/validating message - focus, then blur",
+      () => {
+        let app = renderApp()
+
+        act(() => app->email.input->FireEvent.focus)
+
+        act(() => app->email.input->FireEvent.blur)
+
+        email.expectToMatchSnapshot(app)
+      },
+    )
+
+    testAsync(
+      "Change focus status and trigger already exists error - focus, type email address, then blur",
+      done => {
+        let app = renderApp()
+
+        act(() => app->email.input->FireEvent.focus)
+
+        act(() =>
+          app->email.input->FireEvent.input(~eventInit={"target": {"value": existingEmail}})
+        )
+
+        act(() => app->email.input->FireEvent.blur)
+
+        Js.Global.setTimeout(() => done(email.expectToMatchSnapshot(app)), 300)->ignore
+      },
+    )
+
+    testAsync("Change focus status and trigger required error - focus then blur", done => {
       let app = renderApp()
 
-      app->email.input->FireEvent.focus
+      act(() => app->email.input->FireEvent.focus)
 
-      app->email.input->FireEvent.blur
+      act(() => app->email.input->FireEvent.blur)
 
-      email.expectToMatchSnapshot(app)
+      Js.Global.setTimeout(() => done(email.expectToMatchSnapshot(app)), 300)->ignore
     })
 
     test("Email format error", () => {
@@ -51,7 +83,6 @@ describe("Formidable", () => {
             "value": wrongEmail,
           },
         },
-        _,
       )
 
       email.expectToMatchSnapshot(app)
@@ -60,15 +91,16 @@ describe("Formidable", () => {
     test("Updates value", () => {
       let app = renderApp()
 
-      app
-      ->email.input
-      ->FireEvent.input(
-        ~eventInit={
-          "target": {
-            "value": validEmail,
+      act(() =>
+        app
+        ->email.input
+        ->FireEvent.input(
+          ~eventInit={
+            "target": {
+              "value": validEmail,
+            },
           },
-        },
-        _,
+        )
       )
 
       email.expectToMatchSnapshot(app)
@@ -77,7 +109,7 @@ describe("Formidable", () => {
     test("Submit errors", () => {
       let app = renderApp()
 
-      app->submitButton->FireEvent.click
+      act(() => app->submitButton->FireEvent.click)
 
       email.expectToMatchSnapshot(app)
     })
@@ -85,9 +117,9 @@ describe("Formidable", () => {
     test("Submit and reset", () => {
       let app = renderApp()
 
-      app->submitButton->FireEvent.click
+      act(() => app->submitButton->FireEvent.click)
 
-      app->resetButton->FireEvent.click
+      act(() => app->resetButton->FireEvent.click)
 
       email.expectToMatchSnapshot(app)
     })
@@ -95,18 +127,19 @@ describe("Formidable", () => {
     test("Submit with errors", () => {
       let app = renderApp()
 
-      app
-      ->email.input
-      ->FireEvent.input(
-        ~eventInit={
-          "target": {
-            "value": wrongEmail,
+      act(() =>
+        app
+        ->email.input
+        ->FireEvent.input(
+          ~eventInit={
+            "target": {
+              "value": wrongEmail,
+            },
           },
-        },
-        _,
+        )
       )
 
-      app->submitButton->FireEvent.click
+      act(() => app->submitButton->FireEvent.click)
 
       email.expectToMatchSnapshot(app)
     })
@@ -116,7 +149,7 @@ describe("Formidable", () => {
 
       let app = renderApp()
 
-      app->email.input->FireEvent.focus
+      act(() => app->email.input->FireEvent.focus)
 
       Handler.expectToMatchSnapshot(spy)
     })
@@ -134,7 +167,7 @@ describe("Formidable", () => {
 
       let app = renderApp(~onFocus, ())
 
-      app->email.input->FireEvent.blur
+      act(() => app->email.input->FireEvent.blur)
 
       Handler.expectToMatchSnapshot(spy)
     })
@@ -144,7 +177,7 @@ describe("Formidable", () => {
 
       let app = renderApp(~onFocus, ())
 
-      app->email.input->FireEvent.focus
+      act(() => app->email.input->FireEvent.focus)
 
       Handler.expectToMatchSnapshot(spy)
     })
@@ -154,7 +187,7 @@ describe("Formidable", () => {
 
       let app = renderApp()
 
-      app->email.input->FireEvent.blur
+      act(() => app->email.input->FireEvent.blur)
 
       Handler.expectToMatchSnapshot(spy)
     })
@@ -172,7 +205,7 @@ describe("Formidable", () => {
 
       let app = renderApp(~onBlur, ())
 
-      app->email.input->FireEvent.focus
+      act(() => app->email.input->FireEvent.focus)
 
       Handler.expectToMatchSnapshot(spy)
     })
@@ -182,7 +215,7 @@ describe("Formidable", () => {
 
       let app = renderApp(~onBlur, ())
 
-      app->email.input->FireEvent.blur
+      act(() => app->email.input->FireEvent.blur)
 
       Handler.expectToMatchSnapshot(spy)
     })
@@ -192,37 +225,40 @@ describe("Formidable", () => {
 
       let app = renderApp(~onChange, ())
 
-      app
-      ->email.input
-      ->FireEvent.input(
-        ~eventInit={
-          "target": {
-            "value": "foo@",
+      act(() =>
+        app
+        ->email.input
+        ->FireEvent.input(
+          ~eventInit={
+            "target": {
+              "value": "foo@",
+            },
           },
-        },
-        _,
+        )
       )
 
-      app
-      ->email.input
-      ->FireEvent.input(
-        ~eventInit={
-          "target": {
-            "value": "bar.",
+      act(() =>
+        app
+        ->email.input
+        ->FireEvent.input(
+          ~eventInit={
+            "target": {
+              "value": "bar.",
+            },
           },
-        },
-        _,
+        )
       )
 
-      app
-      ->email.input
-      ->FireEvent.input(
-        ~eventInit={
-          "target": {
-            "value": "com",
+      act(() =>
+        app
+        ->email.input
+        ->FireEvent.input(
+          ~eventInit={
+            "target": {
+              "value": "com",
+            },
           },
-        },
-        _,
+        )
       )
 
       Handler.expectToMatchSnapshot(spy)

--- a/tests/__snapshots__/Formidable_Test.bs.js.snap
+++ b/tests/__snapshots__/Formidable_Test.bs.js.snap
@@ -129,6 +129,22 @@ Object {
 }
 `;
 
+exports[`Formidable Field (example: email) Change focus status and trigger already exists error - focus, type email address, then blur 1`] = `
+Object {
+  "focusState": "Blur",
+  "status": "Field has errors: already exists/email",
+  "value": "already@exists.com",
+}
+`;
+
+exports[`Formidable Field (example: email) Change focus status and trigger only displays loading/validating message - focus, then blur 1`] = `
+Object {
+  "focusState": "Blur",
+  "status": "Validating...",
+  "value": "",
+}
+`;
+
 exports[`Formidable Field (example: email) Change focus status and trigger required error - focus then blur 1`] = `
 Object {
   "focusState": "Blur",


### PR DESCRIPTION
closes https://github.com/scoville/re-formidable/issues/20

So far manual validation are "unsafe" as they rely on the name, so a string. The good thing is that
1/ We rarely need them
2/ Using strings is pretty fast

I think we can keep things as is for now if you're with that and see how we can seamlessly integrate some wider solution to the library. But we need to keep the React way even if we do so 😕 