### PR TITLE
Move out handlers logic to make it reactive

### DIFF
--- a/src/FormidableEvents.res
+++ b/src/FormidableEvents.res
@@ -22,7 +22,12 @@ let handleWithValue = (~preventDefault=false, ~stopPropagation=false, f, event) 
   event->eventTargetValue->f
 }
 
-let handle = (~preventDefault=false, ~stopPropagation=false, f, event) => {
+let handleAndIgnore = (~preventDefault=false, ~stopPropagation=false, f, event) => {
   handle_(~preventDefault, ~stopPropagation, event)
   f()
+}
+
+let handle = (~preventDefault=false, ~stopPropagation=false, f, event) => {
+  handle_(~preventDefault, ~stopPropagation, event)
+  f(event)
 }

--- a/tests/__snapshots__/Formidable_Test.bs.js.snap
+++ b/tests/__snapshots__/Formidable_Test.bs.js.snap
@@ -105,17 +105,38 @@ exports[`Formidable Component renders 1`] = `
         Field is pristine
       </div>
     </div>
+    <div>
+      <div>
+        Hobby - 1
+      </div>
+      <input
+        data-testid="hobby-0"
+        name="hobby-0"
+        value=""
+      />
+      <div>
+        Blur
+      </div>
+      <div>
+        Field is pristine
+      </div>
+    </div>
     <button
-      data-testid="submit"
-      type="submit"
+      type="button"
     >
-      Submit
+      Add Hobby
     </button>
     <button
       data-testid="reset"
       type="button"
     >
       Reset
+    </button>
+    <button
+      data-testid="submit"
+      type="submit"
+    >
+      Submit
     </button>
   </form>
 </div>


### PR DESCRIPTION
closes https://github.com/scoville/re-formidable/issues/26

Pushing more and more the React way to handle submit success/error.

Until now, it was possible to do something like this:

```rescript
let {state: {values}} = Form.use(~onSuccess=values => Js.log(values), ())
```

From now on we have to use the useEffect hook:

```rescript
let {computedState: {formStatus}, state: {values}} = Form.use()

React.useEffect1(() => {
    switch formStatus {
    | #submitted(#valid(values)) => Js.log2("Success: ", values)
    | _ => ignore()
    }

    None
  }, [formStatus])
```

Fortunately we also have access to a new hook:

```rescript
let {computedState: {formStatus}, state: {values}} as form = Form.use()

Form.useOnSubmitSuccess(~form, (~values) => Js.log2("Success: ", values))

// In the future we can consider adding dependencies support like this:
Form.useOnSubmitSuccess1(~form, (~values) => !disabled ? Js.log2("Success: ", values) : ignore, [disabled])
```

Submit error has the same api.
