### PR TITLE
Force cmp function for error and validation label types

### DIFF
--- a/example/Components.res
+++ b/example/Components.res
@@ -8,7 +8,7 @@ module Errors = {
   let make = (~value: array<I18n.Error.t>) => {
     <div style={ReactDOMStyle.make(~color="red", ())}>
       {value
-      ->Array.map((#error(name, _) as error) =>
+      ->Js.Array2.map((#error(name, _) as error) =>
         <div key=name> {`Field has errors: ${I18n.translate(error)}`->React.string} </div>
       )
       ->React.array}

--- a/example/I18n.res
+++ b/example/I18n.res
@@ -1,5 +1,7 @@
-module Error = {
+module Error = Id.MakeComparable({
   type t = [#error(string, option<string>)]
-}
+
+  let cmp = Pervasives.compare
+})
 
 let translate = (#error(name, label)) => `${label->Option.getWithDefault("")}/${name}`

--- a/example/Validations.res
+++ b/example/Validations.res
@@ -1,8 +1,10 @@
 include Formidable.Validations
 
-module Label = {
+module Label = Id.MakeComparable({
   type t = [#required | #email | #equals]
-}
+
+  let cmp = Pervasives.compare
+})
 
 let required = (
   #name(#required),

--- a/src/FormidableExtra.res
+++ b/src/FormidableExtra.res
@@ -1,5 +1,5 @@
 module ArrayExtra = {
-  let flatMap = (xs, f) => xs->Array.reduce([], (acc, x) => acc->Js.Array2.concat(f(x)))
+  let flatMap = (xs, f) => xs->Js.Array2.reduce((acc, x) => acc->Js.Array2.concat(f(x)), [])
 }
 
 module OptionExtra = {


### PR DESCRIPTION
Addresses the second issue mentioned [here](https://github.com/scoville/re-formidable/issues/33).

The API is slightly more complex, but gives also more power to the end user to define their own equality heuristic for label validations and errors.