### PR TITLE
Force eq function for error and validation label types

### DIFF
--- a/example/Components.res
+++ b/example/Components.res
@@ -8,7 +8,7 @@ module Errors = {
   let make = (~value: array<I18n.Error.t>) => {
     <div style={ReactDOMStyle.make(~color="red", ())}>
       {value
-      ->Array.map((#error(name, _) as error) =>
+      ->Js.Array2.map((#error(name, _) as error) =>
         <div key=name> {`Field has errors: ${I18n.translate(error)}`->React.string} </div>
       )
       ->React.array}

--- a/example/I18n.res
+++ b/example/I18n.res
@@ -1,5 +1,7 @@
 module Error = {
   type t = [#error(string, option<string>)]
+
+  let eq = (error1, error2) => error1 == error2
 }
 
 let translate = (#error(name, label)) => `${label->Option.getWithDefault("")}/${name}`

--- a/example/Validations.res
+++ b/example/Validations.res
@@ -2,6 +2,8 @@ include Formidable.Validations
 
 module Label = {
   type t = [#required | #email | #equals]
+
+  let eq = (label1, label2) => label1 == label2
 }
 
 let required = (

--- a/src/Formidable.res
+++ b/src/Formidable.res
@@ -3,12 +3,20 @@ open FormidableExtra
 module Events = FormidableEvents
 module Validations = FormidableValidations
 
-module type Type = {
+module type Error = {
   type t
+
+  let eq: (t, t) => bool
+}
+
+module type ValidationLabel = {
+  type t
+
+  let eq: (t, t) => bool
 }
 
 module type Values = {
-  include Type
+  type t
 
   let init: t
 }
@@ -210,7 +218,7 @@ module type Form = {
   ) => React.element
 }
 
-module Make = (ValidationLabel: Type, Error: Type, Values: Values): (
+module Make = (ValidationLabel: ValidationLabel, Error: Error, Values: Values): (
   Form
     with type values = Values.t
     and type error = Error.t
@@ -262,7 +270,7 @@ module Make = (ValidationLabel: Type, Error: Type, Values: Values): (
       updateFieldStatus(name, status => {
         switch status {
         | #touched | #pristine | #valid => #errors([error])
-        | #errors(errors) when errors->Js.Array2.includes(error) => status
+        | #errors(errors) when errors->Js.Array2.some(Error.eq(error)) => status
         | #errors(errors) => errors->Js.Array2.concat([error])->#errors
         }
       })
@@ -394,7 +402,7 @@ module Make = (ValidationLabel: Type, Error: Type, Values: Values): (
           validations->ArrayExtra.flatMap(Validations.getNames)
         )
 
-      let hasValidation = name => validationNames->Js.Array2.includes(name)
+      let hasValidation = name => validationNames->Js.Array2.some(ValidationLabel.eq(name))
 
       let validate = React.useCallback1((validationContext, values) =>
         validations->Option.mapWithDefault(#valid, validations =>
@@ -524,8 +532,8 @@ type t<'validationLabel, 'error, 'values> = module(Form with
 
 let make = (
   type validationLabel error values,
-  ~validationLabel as module(ValidationLabel: Type with type t = validationLabel),
-  ~error as module(Error: Type with type t = error),
+  ~validationLabel as module(ValidationLabel: ValidationLabel with type t = validationLabel),
+  ~error as module(Error: Error with type t = error),
   ~values as module(Values: Values with type t = values),
 ): t<validationLabel, error, values> => {
   module(Make(ValidationLabel, Error, Values))
@@ -533,8 +541,8 @@ let make = (
 
 let use = (
   type validationLabel error values,
-  ~validationLabel: module(Type with type t = validationLabel),
-  ~error: module(Type with type t = error),
+  ~validationLabel: module(ValidationLabel with type t = validationLabel),
+  ~error: module(Error with type t = error),
   ~values: module(Values with type t = values),
   ~initFormStatus: option<States.Form.Status.t<values, error>>=?,
   (),
@@ -548,8 +556,8 @@ let use = (
 
 let use1 = (
   type validationLabel error values,
-  ~validationLabel: module(Type with type t = validationLabel),
-  ~error: module(Type with type t = error),
+  ~validationLabel: module(ValidationLabel with type t = validationLabel),
+  ~error: module(Error with type t = error),
   ~values: module(Values with type t = values),
   ~initFormStatus: option<States.Form.Status.t<values, error>>=?,
 ) => {

--- a/src/FormidableExtra.res
+++ b/src/FormidableExtra.res
@@ -1,5 +1,5 @@
 module ArrayExtra = {
-  let flatMap = (xs, f) => xs->Array.reduce([], (acc, x) => acc->Js.Array2.concat(f(x)))
+  let flatMap = (xs, f) => xs->Js.Array2.reduce((acc, x) => acc->Js.Array2.concat(f(x)), [])
 }
 
 module OptionExtra = {


### PR DESCRIPTION
Alternative to #37 
Instead of using the internal `Comparable` module and the hacky `getCmpInternal` function, we introduce our own types.
It ends up being simpler and easier to read and write 😕 

In most case where the user uses variants or polymophic variants `==` is enough anyway.