### PR TITLE
Use result instead of weird poly variant

### DIFF
--- a/example/Validations.res
+++ b/example/Validations.res
@@ -10,8 +10,8 @@ let required = (
   #name(#required),
   ({Validator.Args.label: label, value}) =>
     switch value {
-    | "" => #error(#error(("required", label)))
-    | _ => #ok(value)
+    | "" => Error(#error(("required", label)))
+    | _ => Ok(value)
     },
 )
 
@@ -21,9 +21,9 @@ let email = (
   #name(#email),
   ({Validator.Args.label: label, value}) =>
     if emailRegEx->Js.Re.test_(value) {
-      #ok(value)
+      Ok(value)
     } else {
-      #error(#error(("email", label)))
+      Error(#error(("email", label)))
     },
 )
 
@@ -31,8 +31,8 @@ let equals = lens => (
   #name(#equals),
   ({Validator.Args.label: label, value, values}) =>
     if lens.Optic.Lens.get(values) == value {
-      #ok(value)
+      Ok(value)
     } else {
-      #error(#error(("equals", label)))
+      Error(#error(("equals", label)))
     },
 )

--- a/src/Formidable.res
+++ b/src/Formidable.res
@@ -417,8 +417,8 @@ module Make = (ValidationLabel: ValidationLabel, Error: Error, Values: Values): 
                 value: Optic.Lens.get(lens, values),
                 values: values,
               }) {
-              | #ok(_) => None
-              | #error(error) => Some(error)
+              | Ok(_) => None
+              | Error(error) => Some(error)
               }
             } else {
               None

--- a/src/FormidableValidations.res
+++ b/src/FormidableValidations.res
@@ -7,7 +7,7 @@ module Strategy = {
 
 @ocaml.doc(`The value returned by a validator, ok or error`)
 module Value = {
-  type t<'value, 'error> = [#ok('value) | #error('error)]
+  type t<'value, 'error> = result<'value, 'error>
 }
 
 @ocaml.doc(`The validator is the function that performs the validation`)
@@ -49,8 +49,8 @@ let compose = ((names, validator), (names', validator')) => (
   names->Description.resolveKind->Js.Array2.concat(names'->Description.resolveKind)->#names,
   field =>
     switch validator(field) {
-    | #ok(_) => validator'(field)
-    | #error(_) as error => error
+    | Ok(_) => validator'(field)
+    | Error(_) as error => error
     },
 )
 


### PR DESCRIPTION
Not sure why we used to need a poly variant instead of a proper result type. Probably some legacy code. Cleaned.